### PR TITLE
BUG: made dependency names strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(name='blackbox',
       packages=find_packages(),
       install_requires=
       [
-          ujson,
-          msgpack,
-          msgpack_numpy
+          'ujson',
+          'msgpack-python',
+          'msgpack_numpy'
       ])
       


### PR DESCRIPTION
changed 'install_requires' dependencies to be strings. Changed the name of the message pack package to be 'msgpack-python' rather than 'msg-pack'